### PR TITLE
Realtime thread priority

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -46,7 +46,7 @@ Next, each histogram is transformed into the frequency domain by applying the [d
 
 A physical state change of a key switch usually goes through multiple different processing steps before reaching a Windows application: microcontroller key scanning (optionally with a debounce filter), USB reporting, computer OS input handling, task switching time, application response time. While the OS time can be treated as unpredictable continuous noise (as Windows is non-RTOS), the former processes have very strict sampling rates.
 
-The frequency domain is useful for detecting periodicity in the data, such as the key scanning rate and/or USB report rate. If the data is too noisy, increase the sample size by recording more data. Booting your system in safe mode is also very effective in minimizing noise in the recording.
+The frequency domain is useful for detecting periodicity in the data, such as the key scanning rate and/or USB report rate. If the data is too noisy, increase the sample size by recording more data. Running the application as administrator or booting your system in safe mode is also very effective in minimizing noise in the recording.
 
 ### Analysis parameters
 

--- a/Keyboard Inspector/Program.cs
+++ b/Keyboard Inspector/Program.cs
@@ -44,6 +44,10 @@ namespace Keyboard_Inspector {
 
         [STAThread]
         static void Main(string[] args) {
+            // .NET API doesn't expose this
+            var nativeProcess = Native.GetCurrentProcess();
+            Native.SetPriorityClass(nativeProcess, 0x100); // REALTIME_PRIORITY_CLASS
+
             Args = args;
 
             if (!Directory.Exists(Constants.DataDir))

--- a/Keyboard Inspector/Recording/ListenerWindow.cs
+++ b/Keyboard Inspector/Recording/ListenerWindow.cs
@@ -45,6 +45,9 @@ namespace Keyboard_Inspector {
             Native.RegisterClassEx(ref wc);
 
             var thread = new Thread(() => {
+                var nativeThread = Native.GetCurrentThread();
+                Native.SetThreadPriority(nativeThread, 15);
+
                 hWnd = Native.CreateWindowEx(
                     0, CLASS_NAME, "Keyboard Inspector Listener", 0,
                     Native.CW_USEDEFAULT, Native.CW_USEDEFAULT, Native.CW_USEDEFAULT, Native.CW_USEDEFAULT,
@@ -63,7 +66,7 @@ namespace Keyboard_Inspector {
 
                 throw new Exception("ListenerWindow WM_QUIT");
             });
-            thread.Priority = ThreadPriority.Highest;
+            // thread.Priority = ThreadPriority.Highest;
             thread.Start();
         }
 

--- a/Keyboard Inspector/Recording/ListenerWindow.cs
+++ b/Keyboard Inspector/Recording/ListenerWindow.cs
@@ -45,6 +45,7 @@ namespace Keyboard_Inspector {
             Native.RegisterClassEx(ref wc);
 
             var thread = new Thread(() => {
+                // We set thread priority here, since .NET API doesn't expose Realtime priority
                 var nativeThread = Native.GetCurrentThread();
                 Native.SetThreadPriority(nativeThread, 15);
 

--- a/Keyboard Inspector/Recording/ListenerWindow.cs
+++ b/Keyboard Inspector/Recording/ListenerWindow.cs
@@ -45,9 +45,9 @@ namespace Keyboard_Inspector {
             Native.RegisterClassEx(ref wc);
 
             var thread = new Thread(() => {
-                // We set thread priority here, since .NET API doesn't expose Realtime priority
+                // .NET API doesn't expose this
                 var nativeThread = Native.GetCurrentThread();
-                Native.SetThreadPriority(nativeThread, 15);
+                Native.SetThreadPriority(nativeThread, 15); // THREAD_PRIORITY_TIME_CRITICAL
 
                 hWnd = Native.CreateWindowEx(
                     0, CLASS_NAME, "Keyboard Inspector Listener", 0,
@@ -67,7 +67,6 @@ namespace Keyboard_Inspector {
 
                 throw new Exception("ListenerWindow WM_QUIT");
             });
-            // thread.Priority = ThreadPriority.Highest;
             thread.Start();
         }
 

--- a/Keyboard Inspector/Recording/Native.cs
+++ b/Keyboard Inspector/Recording/Native.cs
@@ -757,5 +757,11 @@ namespace Keyboard_Inspector {
 
         [DllImport("user32.dll")]
         public static extern bool DispatchMessage([In] ref MSG msg);
+
+        [DllImport("kernel32.dll")]
+        public static extern IntPtr GetCurrentThread();
+
+        [DllImport("kernel32.dll")]
+        public static extern bool SetThreadPriority(IntPtr hThread, int nPriority);
     }
 }

--- a/Keyboard Inspector/Recording/Native.cs
+++ b/Keyboard Inspector/Recording/Native.cs
@@ -763,5 +763,11 @@ namespace Keyboard_Inspector {
 
         [DllImport("kernel32.dll")]
         public static extern bool SetThreadPriority(IntPtr hThread, int nPriority);
+
+        [DllImport("kernel32.dll")]
+        public static extern IntPtr GetCurrentProcess();
+
+        [DllImport("kernel32.dll")]
+        public static extern bool SetPriorityClass(IntPtr hProcess, int dwPriorityClass);
     }
 }

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ At the top, three graphs show different methods of interpreting the data in the 
 
 Three more graphs are displayed under showing the frequency domains of these histograms by applying the discrete Fourier transform. Interpreting these can a be a little tricky and although not always the case, **the largest peak is generally the effective report rate of the device**. In most cases, this will coincide with the device's USB report rate.
 
-If the data is too noisy or has multiple peaks, recording more input data helps with increasing the sample size. Booting your system in safe mode is also very effective in minimizing noise in the recording. Applying iterations of HPS partial elimination can help isolate the fundamental peak. If no clear peak presents itself, try increasing the binning rate, as it might be outside the range you're analyzing. 
+If the data is too noisy or has multiple peaks, recording more input data helps with increasing the sample size. Running the application as administrator or booting your system in safe mode is also very effective in minimizing noise in the recording. Applying iterations of HPS partial elimination can help isolate the fundamental peak. If no clear peak presents itself, try increasing the binning rate, as it might be outside the range you're analyzing. 
 
 The binning rate is set to 4000 Hz by default, which will let you comfortably analyze full speed USB devices (which support up to 1000 Hz). Increase this value if you need to analyze higher report rate devices such as high speed USB devices (which support up to 8000 Hz).
 


### PR DESCRIPTION
Screenshot showing CLR thread running at priority 15
![image](https://github.com/user-attachments/assets/bd2410a3-1e91-4a1d-a0b4-31236b1ae267)

I can't test the effect of this since I don't have high rate keyboards, but we can get a test build out and see.

Fixes #54 